### PR TITLE
Changed all functions and modules to Recording and Sorting nomenclature

### DIFF
--- a/examples/demo_mearec_extractors.ipynb
+++ b/examples/demo_mearec_extractors.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -14,11 +14,16 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/alessiob/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
+     "ename": "ImportError",
+     "evalue": "cannot import name 'NumpyRecordingExtractor' from 'spikeinterface.extractors.numpyextractors.numpyextractors' (/home/cole/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/extractors/numpyextractors/numpyextractors.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-3-7cbfbe7fe429>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0mappend_to_path\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetcwd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'/..'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 16\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mspikeinterface\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0msi\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     17\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0mappend_to_path\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetcwd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'/../../spike-collab/widgets/timeserieswidget/'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mextractors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbiocamrecordingextractor\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mBiocamRecordingExtractor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mextractors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhs2sortingextractor\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mHS2SortingExtractor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 12\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mextractors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnumpyextractors\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNumpyRecordingExtractor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNumpySortingExtractor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/extractors/numpyextractors/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mnumpyextractors\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNumpyRecordingExtractor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mNumpySortingExtractor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'NumpyRecordingExtractor' from 'spikeinterface.extractors.numpyextractors.numpyextractors' (/home/cole/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/extractors/numpyextractors/numpyextractors.py)"
      ]
     }
    ],
@@ -160,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/examples/demo_spikeinterface_biocam.ipynb
+++ b/examples/demo_spikeinterface_biocam.ipynb
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started_with_recording_extractors.ipynb
+++ b/examples/getting_started_with_recording_extractors.ipynb
@@ -38,99 +38,99 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define the in-memory input extractor\n",
-    "IX=si.NumpyInputExtractor(timeseries=timeseries,geom=geom,samplerate=samplerate)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Num. channels = 7\n",
-      "Sampling frequency = 30000 Hz\n",
-      "Num. timepoints = 600000\n",
-      "Stdev. on third channel = 9.99206377601932\n",
-      "Location of third electrode = [ 2.  0.]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Demonstrate the API for extracting information\n",
-    "print('Num. channels = {}'.format(IX.getNumChannels()))\n",
-    "print('Sampling frequency = {} Hz'.format(IX.getSamplingFrequency()))\n",
-    "print('Num. timepoints = {}'.format(IX.getNumFrames()))\n",
-    "print('Stdev. on third channel = {}'.format(np.std(IX.getRawTraces(channel_ids=2))))\n",
-    "print('Location of third electrode = {}'.format(IX.getChannelInfo(channel_id=2)['location']))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Write this dataset in the MountainSort format\n",
-    "si.MdaInputExtractor.writeDataset(input_extractor=IX,output_dirname='sample_mountainsort_dataset')"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Read this dataset with the Mda input extractor\n",
-    "IX2=si.MdaInputExtractor(dataset_directory='sample_mountainsort_dataset')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Num. channels = 7\n",
-      "Sampling frequency = 30000 Hz\n",
-      "Num. timepoints = 600000\n",
-      "Stdev. on third channel = 9.992064476013184\n",
-      "Location of third electrode = [ 2.  0.]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# We should get he same information as above\n",
-    "print('Num. channels = {}'.format(IX2.getNumChannels()))\n",
-    "print('Sampling frequency = {} Hz'.format(IX2.getSamplingFrequency()))\n",
-    "print('Num. timepoints = {}'.format(IX2.getNumFrames()))\n",
-    "print('Stdev. on third channel = {}'.format(np.std(IX2.getRawTraces(channel_ids=2))))\n",
-    "print('Location of third electrode = {}'.format(IX2.getChannelInfo(channel_id=2)['location']))"
+    "# Define the in-memory recording extractor\n",
+    "RX=si.NumpyRecordingExtractor(timeseries=timeseries,geom=geom,samplerate=samplerate)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num. channels = 7\n",
+      "Sampling frequency = 30000 Hz\n",
+      "Num. timepoints = 600000\n",
+      "Stdev. on third channel = 10.00845104974044\n",
+      "Location of third electrode = [2. 0.]\n"
+     ]
+    }
+   ],
    "source": [
-    "# Represent a sub-dataset\n",
-    "IX3=si.SubInputExtractor(parent_extractor=IX2,channel_ids=[2,3,4,5],start_frame=1000,end_frame=8000)"
+    "# Demonstrate the API for extracting information\n",
+    "print('Num. channels = {}'.format(RX.getNumChannels()))\n",
+    "print('Sampling frequency = {} Hz'.format(RX.getSamplingFrequency()))\n",
+    "print('Num. timepoints = {}'.format(RX.getNumFrames()))\n",
+    "print('Stdev. on third channel = {}'.format(np.std(RX.getTraces(channel_ids=2))))\n",
+    "print('Location of third electrode = {}'.format(RX.getChannelInfo(channel_id=2)['location']))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write this dataset in the MountainSort format\n",
+    "si.MdaRecordingExtractor.writeRecordedData(recording_extractor=RX,output_dirname='sample_mountainsort_dataset')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read this dataset with the Mda recording extractor\n",
+    "RX2=si.MdaRecordingExtractor(dataset_directory='sample_mountainsort_dataset')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num. channels = 7\n",
+      "Sampling frequency = 30000 Hz\n",
+      "Num. timepoints = 600000\n",
+      "Stdev. on third channel = 10.008451461791992\n",
+      "Location of third electrode = [2. 0.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We should get he same information as above\n",
+    "print('Num. channels = {}'.format(RX2.getNumChannels()))\n",
+    "print('Sampling frequency = {} Hz'.format(RX2.getSamplingFrequency()))\n",
+    "print('Num. timepoints = {}'.format(RX2.getNumFrames()))\n",
+    "print('Stdev. on third channel = {}'.format(np.std(RX2.getTraces(channel_ids=2))))\n",
+    "print('Location of third electrode = {}'.format(RX2.getChannelInfo(channel_id=2)['location']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Represent a sub-dataset\n",
+    "RX3=si.SubRecordingExtractor(parent_extractor=RX2,channel_ids=[2,3,4,5],start_frame=1000,end_frame=8000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -140,18 +140,18 @@
       "Num. channels = 4\n",
       "Sampling frequency = 30000 Hz\n",
       "Num. timepoints = 7000\n",
-      "Stdev. on third channel = 10.059552192687988\n",
-      "Location of third electrode = [ 4.  0.]\n"
+      "Stdev. on third channel = 10.011518478393555\n",
+      "Location of third electrode = [4. 0.]\n"
      ]
     }
    ],
    "source": [
     "# Show the information for this sub-dataset\n",
-    "print('Num. channels = {}'.format(IX3.getNumChannels()))\n",
-    "print('Sampling frequency = {} Hz'.format(IX3.getSamplingFrequency()))\n",
-    "print('Num. timepoints = {}'.format(IX3.getNumFrames()))\n",
-    "print('Stdev. on third channel = {}'.format(np.std(IX3.getRawTraces(channel_ids=2))))\n",
-    "print('Location of third electrode = {}'.format(IX3.getChannelInfo(channel_id=2)['location']))"
+    "print('Num. channels = {}'.format(RX3.getNumChannels()))\n",
+    "print('Sampling frequency = {} Hz'.format(RX3.getSamplingFrequency()))\n",
+    "print('Num. timepoints = {}'.format(RX3.getNumFrames()))\n",
+    "print('Stdev. on third channel = {}'.format(np.std(RX3.getTraces(channel_ids=2))))\n",
+    "print('Location of third electrode = {}'.format(RX3.getChannelInfo(channel_id=2)['location']))"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started_with_sorting_extractors.ipynb
+++ b/examples/getting_started_with_sorting_extractors.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,23 +37,23 @@
     "geom=np.zeros((num_channels,2))\n",
     "geom[:,0]=range(num_channels)\n",
     "\n",
-    "# Define the in-memory input extractor\n",
-    "IX=si.NumpyInputExtractor(timeseries=timeseries,geom=geom,samplerate=samplerate)\n",
+    "# Define the in-memory recording extractor\n",
+    "RX=si.NumpyRecordingExtractor(timeseries=timeseries,geom=geom,samplerate=samplerate)\n",
     "\n",
     "# Generate some random events\n",
     "times=np.sort(np.random.uniform(0,num_timepoints,num_events))\n",
     "labels=np.random.randint(1,num_units+1,size=num_events)\n",
     "    \n",
-    "# Define the in-memory output extractor\n",
-    "OX=si.NumpyOutputExtractor()\n",
+    "# Define the in-memory sorting extractor\n",
+    "SX=si.NumpySortingExtractor()\n",
     "for k in range(1,num_units+1):\n",
     "    times_k=times[np.where(labels==k)[0]]\n",
-    "    OX.addUnit(unit_id=k,times=times_k)"
+    "    SX.addUnit(unit_id=k,times=times_k)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -61,80 +61,71 @@
      "output_type": "stream",
      "text": [
       "Unit ids = [1, 2, 3, 4]\n",
-      "Num. events for unit 1 = 234\n",
-      "Num. events for first second of unit 1 = 16\n"
+      "Num. events for unit 1 = 268\n",
+      "Num. events for first second of unit 1 = 15\n"
      ]
     }
    ],
    "source": [
     "# Demonstrate the API for extracting information\n",
-    "print('Unit ids = {}'.format(OX.getUnitIds()))\n",
-    "st=OX.getUnitSpikeTrain(unit_id=1)\n",
+    "print('Unit ids = {}'.format(SX.getUnitIds()))\n",
+    "st=SX.getUnitSpikeTrain(unit_id=1)\n",
     "print('Num. events for unit 1 = {}'.format(len(st)))\n",
-    "st1=OX.getUnitSpikeTrain(unit_id=1,start_frame=0,end_frame=30000)\n",
+    "st1=SX.getUnitSpikeTrain(unit_id=1,start_frame=0,end_frame=30000)\n",
     "print('Num. events for first second of unit 1 = {}'.format(len(st1)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Write the input/output in the MountainSort format\n",
-    "si.MdaInputExtractor.writeDataset(input_extractor=IX,output_dirname='sample_mountainsort_dataset')\n",
-    "si.MdaOutputExtractor.writeFirings(output_extractor=OX,firings_out='sample_mountainsort_dataset/firings_true.mda')"
+    "si.MdaRecordingExtractor.writeRecordedData(recording_extractor=IX,output_dirname='sample_mountainsort_dataset')\n",
+    "si.MdaSortingExtractor.writeSortedData(sorting_extractor=OX,firings_out='sample_mountainsort_dataset/firings_true.mda')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Read this dataset with the Mda input extractor\n",
-    "IX2=si.MdaInputExtractor(dataset_directory='sample_mountainsort_dataset')\n",
-    "OX2=si.MdaOutputExtractor(firings_file='sample_mountainsort_dataset/firings_true.mda')"
+    "RX2=si.MdaRecordingExtractor(dataset_directory='sample_mountainsort_dataset')\n",
+    "SX2=si.MdaSortingExtractor(firings_file='sample_mountainsort_dataset/firings_true.mda')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Unit ids = [1, 2, 3, 4]\n",
-      "Num. events for unit 1 = 234\n",
-      "Num. events for first second of unit 1 = 16\n"
+      "Unit ids = [1 2 3 4]\n",
+      "Num. events for unit 1 = 239\n",
+      "Num. events for first second of unit 1 = 15\n"
      ]
     }
    ],
    "source": [
     "# We should get he same information as above\n",
-    "print('Unit ids = {}'.format(OX.getUnitIds()))\n",
-    "st=OX2.getUnitSpikeTrain(unit_id=1)\n",
+    "print('Unit ids = {}'.format(SX2.getUnitIds()))\n",
+    "st=SX2.getUnitSpikeTrain(unit_id=1)\n",
     "print('Num. events for unit 1 = {}'.format(len(st)))\n",
-    "st1=OX2.getUnitSpikeTrain(unit_id=1,start_frame=0,end_frame=30000)\n",
+    "st1=SX2.getUnitSpikeTrain(unit_id=1,start_frame=0,end_frame=30000)\n",
     "print('Num. events for first second of unit 1 = {}'.format(len(st1)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For development purposes, reload imported modules when source changes\n",
     "%load_ext autoreload\n",
@@ -143,9 +134,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'TimeseriesWidget' from 'widgets' (unknown location)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-16-fd334090408b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetcwd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'/../../spike-collab'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mwidgets\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mTimeseriesWidget\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mwidgets\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mUnitWaveformsWidget\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'TimeseriesWidget' from 'widgets' (unknown location)"
+     ]
+    }
+   ],
    "source": [
     "# Note that the following only works if you point the below path to the spike-collab directory\n",
     "\n",
@@ -190,7 +193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/examples/test_spikeinterface_biocam.ipynb
+++ b/examples/test_spikeinterface_biocam.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mhennig/anaconda3/envs/idp/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For development purposes, reload imported modules when source changes\n",
     "%load_ext autoreload\n",
@@ -39,18 +30,26 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# 3Brain data format: 100 signal inversion -1.0\n",
-      "#       signal range:  -4125.0 -  4125.0\n",
-      "# Signal inversion looks like -1.0, guessing the right method for data access.\n",
-      "# If your results look strange, signal polarity is wrong.\n"
+     "ename": "OSError",
+     "evalue": "Unable to open file (unable to open file: name = '/data/MEA/LightStim/P29_16_07_14/10.brw', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mOSError\u001b[0m                                   Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-31ff065ad301>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mA\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBiocamRecordingExtractor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset_directory\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'/data/MEA/LightStim/P29_16_07_14/'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mrecording_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'10.brw'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, dataset_directory, recording_files)\u001b[0m\n\u001b[1;32m     19\u001b[0m             \u001b[0mifile\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset_directory\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrecording_files\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     20\u001b[0m         self._rf, self._nFrames, self._samplingRate, self._nRecCh, self._chIndices, self._file_format, self._signalInv, self._positions, self._read_function = openBiocamFile(\n\u001b[0;32m---> 21\u001b[0;31m             ifile)\n\u001b[0m\u001b[1;32m     22\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mgetNumChannels\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/spikeinterface-0.1.6-py3.7.egg/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py\u001b[0m in \u001b[0;36mopenBiocamFile\u001b[0;34m(filename)\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mopenBiocamFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m     \u001b[0;34m\"\"\"Open a Biocam hdf5 file, read and return the recording info, pick te correct method to access raw data, and return this to the caller.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 52\u001b[0;31m     \u001b[0mrf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5py\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'r'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m     \u001b[0;31m# Read recording variables\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m     \u001b[0mrecVars\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrequire_group\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'3BRecInfo/3BRecVars/'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/h5py-2.8.0-py3.7-linux-x86_64.egg/h5py/_hl/files.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name, mode, driver, libver, userblock_size, swmr, **kwds)\u001b[0m\n\u001b[1;32m    310\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mphil\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    311\u001b[0m                 \u001b[0mfapl\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmake_fapl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdriver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlibver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 312\u001b[0;31m                 \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmake_fid\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muserblock_size\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mswmr\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mswmr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    313\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    314\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mswmr_support\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/lib/python3.7/site-packages/h5py-2.8.0-py3.7-linux-x86_64.egg/h5py/_hl/files.py\u001b[0m in \u001b[0;36mmake_fid\u001b[0;34m(name, mode, userblock_size, fapl, fcpl, swmr)\u001b[0m\n\u001b[1;32m    140\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mswmr\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mswmr_support\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    141\u001b[0m             \u001b[0mflags\u001b[0m \u001b[0;34m|=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mACC_SWMR_READ\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 142\u001b[0;31m         \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfapl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    143\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'r+'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    144\u001b[0m         \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mACC_RDWR\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfapl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mh5py/_objects.pyx\u001b[0m in \u001b[0;36mh5py._objects.with_phil.wrapper\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mh5py/_objects.pyx\u001b[0m in \u001b[0;36mh5py._objects.with_phil.wrapper\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mh5py/h5f.pyx\u001b[0m in \u001b[0;36mh5py.h5f.open\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mOSError\u001b[0m: Unable to open file (unable to open file: name = '/data/MEA/LightStim/P29_16_07_14/10.brw', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)"
      ]
     }
    ],
    "source": [
-    "A = si.BiocamInputExtractor(dataset_directory='/data/MEA/LightStim/P29_16_07_14/',recording_files='10.brw')"
+    "A = si.BiocamRecordingExtractor(dataset_directory='/data/MEA/LightStim/P29_16_07_14/',recording_files='10.brw')"
    ]
   },
   {
@@ -117,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     version="0.1.6",
     author="Cole Hurwitz, Jeremy Magland, Alessio Paolo Buccino, Matthias Hennig",
     author_email="colehurwitz@gmail.com",
-    description="Python interface for extracting spike sorting input and output data from different file types and formats",
+    description="Python interface for extracting recorded and spike sorted extracellular data from different file types and formats",
     url="",
     packages=setuptools.find_packages(),
     package_data={},

--- a/spikeinterface/MultiRecordingExtractor.py
+++ b/spikeinterface/MultiRecordingExtractor.py
@@ -1,0 +1,100 @@
+from .RecordingExtractor import RecordingExtractor
+import numpy as np
+
+class MultiRecordingExtractor(RecordingExtractor):
+    def __init__(self,recording_extractors,epoch_names=None):
+        if epoch_names is None:
+            epoch_names=[str(i) for i in range(len(recording_extractors))]
+        self._RXs=recording_extractors
+        self._epoch_names=epoch_names
+
+        #Num channels and sampling frequency based off the initial extractor
+        self._first_recording_extractor = recording_extractors[0]
+        self._num_channels = self._first_recording_extractor.getNumChannels()
+        self._sampling_frequency = self._first_recording_extractor.getSamplingFrequency()
+
+        #Test if all recording extractors have same num channels and sampling frequency
+        for i, recording_extractor in enumerate(recording_extractors[1:]):
+            num_channels = recording_extractor.getNumChannels()
+            sampling_frequency = recording_extractor.getSamplingFrequency()
+
+            if (self._num_channels != num_channels):
+                raise ValueError("Inconsistent number of channels between extractor 0 and extractor " + str(i + 1))
+            if (self._sampling_frequency != sampling_frequency):
+                raise ValueError("Inconsistent sampling frequency between extractor 0 and extractor " + str(i + 1))
+
+        self._start_frames=[]
+        ff=0
+        for RX in self._RXs:
+            self._start_frames.append(ff)
+            ff=ff+RX.getNumFrames()
+        self._start_frames.append(ff)
+        self._num_frames=ff
+
+    def _find_section_for_frame(self, frame):
+        inds=np.where(np.array(self._start_frames[:-1])<=frame)[0]
+        ind=inds[-1]
+        return self._RXs[ind], ind, frame-self._start_frames[ind]
+
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+        if start_frame is None:
+            start_frame=0
+        if end_frame is None:
+            end_frame=self.getNumFrames()
+        RX1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
+        RX2, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
+        if i_sec1==i_sec2:
+            return RX1.getTraces(start_frame=i_start_frame,end_frame=i_end_frame,channel_ids=channel_ids)
+        list=[]
+        list.append(
+            self._RXs[i_sec1].getTraces(start_frame=i_start_frame,end_frame=self._RXs[i_sec1].getNumFrames(),channel_ids=channel_ids)
+        )
+        if i_sec in range(i_sec1+1,i_sec2):
+            list.append(
+                self._RXs[i_sec].getTraces(channel_ids=channel_ids)
+            )
+        list.append(
+            self._RXs[i_sec2].getTraces(start_frame=0,end_frame=i_end_frame,channel_ids=channel_ids)
+        )
+        return np.concatenate(list,axes=1)
+
+    def getNumChannels(self):
+        return self._num_channels
+
+    def getNumFrames(self):
+        return self._num_frames
+
+    def getSamplingFrequency(self):
+        return self._sampling_frequency
+
+    def frameToTime(self, frame):
+        frame=np.array(frame)
+        ret=np.zeros(frame.shape)
+        min_frame=np.min(frame)
+        max_frame=np.max(frame)
+        RX1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
+        RX2, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
+        for i_sec in range(i_sec1,i_sec2+1):
+            RX=self._RXs[i_sec]
+            inds=np.where(
+                (self._start_frames[i_sec]<=frame)&(frame<self._start_frames[i_sec+1])
+            )[0]
+            ret[inds]=RX.frameToTime(frame-self._start_frames[i_sec])
+        return ret
+
+    def timeToFrame(self, time):
+        raise NotImplementedError("The timeToFrame function is not \
+                                  implemented for this extractor")
+
+    def getChannelInfo(self, channel_id):
+        return self._first_recording_extractor.getChannelInfo(channel_id)
+
+    def getEpochNames(self):
+        return self._epoch_names
+
+    def getEpochInfo(self,epoch_name):
+        ind=self._epoch_names.index(epoch_name)
+        return dict(
+            start_frame=self._start_frames[ind],
+            end_frame=self._start_frames[ind+1]
+        )

--- a/spikeinterface/MultiSortingExtractor.py
+++ b/spikeinterface/MultiSortingExtractor.py
@@ -1,0 +1,44 @@
+from .SortingExtractor import SortingExtractor
+from .RecordingExtractor import RecordingExtractor
+import numpy as np
+
+# Encapsulates a subset of a spike sorted dataset
+
+class MultiSortingExtractor(SortingExtractor):
+    # We need the sorting extractors so that we can determine the number of frames in each
+    def __init__(self, sorting_extractors, recording_extractors, epoch_names=None):
+        self._RXs=recording_extractors
+        self._RX=RecordingExtractor(recording_extractors=recording_extractors)
+        self._SXs=sorting_extractors
+        self._all_unit_ids=[]
+        for SX in self._SXs:
+            unit_ids=SX.getUnitIds()
+            for unit_id in unit_ids:
+                self._all_unit_ids.append(unit_id)
+        self._all_unit_ids=list(set(self._all_unit_ids)) # unique ids
+
+    def getUnitIds(self):
+        return self._all_unit_ids
+
+    def getUnitSpikeTrain(self, unit_id, start_frame=None, end_frame=None):
+        if start_frame is None:
+            start_frame=0
+        if end_frame is None:
+            end_frame=self._RX.getNumFrames()
+        RX1, i_sec1, i_start_frame = self._RX._find_section_for_frame(start_frame)
+        RX2, i_sec2, i_end_frame = self._RX._find_section_for_frame(end_frame)
+        if i_sec1==i_sec2:
+            f0=self._RX._start_frames[i_sec1]
+            return f0+self._SXs[i_sec1].getUnitSpikeTrain(unit_id=unit_id,start_frame=i_start_frame,end_frame=i_end_frame)
+        list=[]
+        list.append(
+            self._RX._start_frames[i_sec1]+self._SXs[i_sec1].getUnitSpikeTrain(unit_id=unit_id,start_frame=i_start_frame,end_frame=self._RXs[i_sec1].getNumFrames())
+        )
+        for i_sec in range(i_sec1+1,i_sec2):
+            list.append(
+                self._RX._start_frames[i_sec]+self._SXs[i_sec].getUnitSpikeTrain(unit_id=unit_id)
+            )
+        list.append(
+            self._RX._start_frames[i_sec2]+self._SXs[i_sec2].getUnitSpikeTrain(unit_id=unit_id,start_frame=0,end_frame=i_end_frame)
+        )
+        return np.concatenate(list)

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 import numpy as np
 
-class InputExtractor(ABC):
+class RecordingExtractor(ABC):
     '''A class that contains functions for extracting important information
-    from input data to spike sorting software. It is an abstract class so all
+    from recorded extracellular data. It is an abstract class so all
     functions with the @abstractmethod tag must be implemented for the
     initialization to work.
 
@@ -13,10 +13,10 @@ class InputExtractor(ABC):
         pass
 
     @abstractmethod
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
-        '''This function extracts and returns a trace from the raw data from the
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+        '''This function extracts and returns a trace from the recorded data from the
         given channels ids and the given start and end frame. It will return
-        raw traces from within three ranges:
+        traces from within three ranges:
 
             [start_frame, t_start+1, ..., end_frame-1]
             [start_frame, start_frame+1, ..., final_recording_frame - 1]
@@ -25,8 +25,8 @@ class InputExtractor(ABC):
 
         if both start_frame and end_frame are given, if only start_frame is
         given, if only end_frame is given, or if neither start_frame or end_frame
-        are given, respectively. Raw traces are returned in a 2D array that
-        contains all of the raw traces from each channel with dimensions
+        are given, respectively. Traces are returned in a 2D array that
+        contains all of the traces from each channel with dimensions
         (num_channels x num_frames). In this implementation, start_frame is inclusive
         and end_frame is exclusive conforming to numpy standards.
 
@@ -42,8 +42,8 @@ class InputExtractor(ABC):
 
         Returns
         ----------
-        raw_traces: numpy.ndarray
-            A 2D array that contains all of the raw traces from each channel.
+        traces: numpy.ndarray
+            A 2D array that contains all of the traces from each channel.
             Dimensions are: (num_channels x num_frames)
         '''
         pass
@@ -114,8 +114,8 @@ class InputExtractor(ABC):
         # Default implementation
         return time*self.getSamplingFrequency()
 
-    def getRawSnippets(self, snippet_len, center_frames, channel_ids=None):
-        '''This function returns raw data snippets from the given channels that
+    def getSnippets(self, snippet_len, center_frames, channel_ids=None):
+        '''This function returns data snippets from the given channels that
         are centered on the given frames and are the length of the given snippet
         length.
 
@@ -132,8 +132,8 @@ class InputExtractor(ABC):
 
         Returns
         ----------
-        raw_snippets: numpy.ndarray
-            Returns a list of the raw snippets as numpy arrays.
+        snippets: numpy.ndarray
+            Returns a list of the snippets as numpy arrays.
             The length of the list is len(center_frames)
             Each array has dimensions: (num_channels x snippet_len)
             Out-of-bounds cases should be handled by filling in zeros in the snippet.
@@ -146,24 +146,25 @@ class InputExtractor(ABC):
         num_channels = len(channel_ids)
         num_frames = self.getNumFrames()
         snippet_half_len = int(snippet_len/2)
-        raw_snippets = []
+        snippets = []
         for i in range(num_snippets):
-            snippet_range = np.array([int(center_frames[i])-snippet_half_len, int(center_frames[i])-snippet_half_len+snippet_len])
-            snippet_buffer = np.array([0,snippet_len])
-            # The following handles the out-of-bounds cases
-            if snippet_range[0] < 0:
-                snippet_buffer[0] -= snippet_range[0]
-                snippet_range[0] -= snippet_range[0]
-            if snippet_range[1] >= num_frames:
-                snippet_buffer[1] -= snippet_range[1] + num_frames
-                snippet_range[1] -= snippet_range[1] + num_frames
             snippet_chunk = np.zeros((num_channels,snippet_len))
-            snippet_chunk[:,snippet_buffer[0]:snippet_buffer[1]] = self.getRawTraces(start_frame=snippet_range[0],
-                                                                                     end_frame=snippet_range[1],
-                                                                                     channel_ids=channel_ids)
-            raw_snippets.append(snippet_chunk)
+            if (0<=center_frames[i]) and (center_frames[i]<num_frames):
+                snippet_range = np.array([int(center_frames[i])-snippet_half_len, int(center_frames[i])-snippet_half_len+snippet_len])
+                snippet_buffer = np.array([0,snippet_len])
+                # The following handles the out-of-bounds cases
+                if snippet_range[0] < 0:
+                    snippet_buffer[0] -= snippet_range[0]
+                    snippet_range[0] -= snippet_range[0]
+                if snippet_range[1] >= num_frames:
+                    snippet_buffer[1] -= snippet_range[1] + num_frames
+                    snippet_range[1] -= snippet_range[1] + num_frames
+                snippet_chunk[:,snippet_buffer[0]:snippet_buffer[1]] = self.getTraces(start_frame=snippet_range[0],
+                                                                                         end_frame=snippet_range[1],
+                                                                                         channel_ids=channel_ids)
+            snippets.append(snippet_chunk)
 
-        return raw_snippets
+        return snippets
 
     def getChannelInfo(self, channel_id):
         '''This function returns the a dictionary containing information about
@@ -193,22 +194,34 @@ class InputExtractor(ABC):
         raise NotImplementedError("The getChannelInfo function is not \
                                   implemented for this extractor")
 
+    def getEpochNames(self):
+        raise NotImplementedError("The getEpochNames function is not \
+                                  implemented for this extractor")
+
+    def getEpochInfo(self,epoch_name):
+        raise NotImplementedError("The getEpochInfo function is not \
+                                  implemented for this extractor")
+
+    def getEpoch(self,epoch_name):
+        from .SubRecordingExtractor import SubRecordingExtractor
+        return SubRecordingExtractor(parent_extractor=self,epoch_name=epoch_name)
+
     @staticmethod
-    def writeInput(self, input_extractor, save_path):
-        '''This function writes out the input file of a given input extractor
-        to the file format of this current input extractor. Allows for easy
-        conversion between input file formats. It is a static method so it
-        can be used without instantiating this input extractor.
+    def writeRecordedData(self, recording_extractor, save_path):
+        '''This function writes out the recorded file of a given recording
+        extractor to the file format of this current recording extractor. Allows
+        for easy conversion between recording file formats. It is a static
+        method so it can be used without instantiating this recording extractor.
 
         Parameters
         ----------
-        input_extractor: InputExtractor
-            An InputExtractor that can extract information from the input file
-            to be converted to the new format.
+        recording_extractor: RecordingExtractor
+            An RecordingExtractor that can extract information from the recording
+            file to be converted to the new format.
 
         save_path: string
-            A path to where the converted input data will be saved, which may
+            A path to where the converted recorded data will be saved, which may
             either be a file or a folder, depending on the format.
         '''
-        raise NotImplementedError("The writeInput function is not \
+        raise NotImplementedError("The writeRecordedData function is not \
                                   implemented for this extractor")

--- a/spikeinterface/SortingExtractor.py
+++ b/spikeinterface/SortingExtractor.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 
-class OutputExtractor(ABC):
+class SortingExtractor(ABC):
     '''A class that contains functions for extracting important information
-    from the output data of spike sorting software. It is an abstract class so
-    all functions with the @abstractmethod tag must be implemented for the
-    initialization to work.
+    from spiked sorted data given a spike sorting software. It is an abstract
+    class so all functions with the @abstractmethod tag must be implemented for
+    the initialization to work.
 
 
     '''
@@ -55,21 +55,21 @@ class OutputExtractor(ABC):
         pass
 
     @staticmethod
-    def writeOutput(self, output_extractor, save_path):
-        '''This function writes out the output file of a given output extractor
-        to the file format of this current output extractor. Allows for easy
-        conversion between output file formats. It is a static method so it
-        can be used without instantiating this output extractor.
+    def writeSortedData(self, sorting_extractor, save_path):
+        '''This function writes out the spike sorted data file of a given sorting
+        extractor to the file format of this current sorting extractor. Allows
+        for easy conversion between spike sorting file formats. It is a static
+        method so it can be used without instantiating this sorting extractor.
 
         Parameters
         ----------
-        output_extractor: OutputExtractor
-            An OutputExtractor that can extract information from the output file
-            to be converted to the new format.
+        sorting_extractor: SortingExtractor
+            A SortingExtractor that can extract information from the sorted data
+            file to be converted to the new format.
 
         save_path: string
-            A path to where the converted output data will be saved, which may
+            A path to where the converted sorted data will be saved, which may
             either be a file or a folder, depending on the format.
         '''
-        raise NotImplementedError("The writeOutput function is not \
+        raise NotImplementedError("The writeSortedData function is not \
                                   implemented for this extractor")

--- a/spikeinterface/SubRecordingExtractor.py
+++ b/spikeinterface/SubRecordingExtractor.py
@@ -1,12 +1,24 @@
-from .InputExtractor import InputExtractor
+from .RecordingExtractor import RecordingExtractor
 import numpy as np
 
 # Encapsulates a sub-dataset
 
-class SubInputExtractor(InputExtractor):
-    def __init__(self, parent_extractor, *, channel_ids=None, start_frame=None, end_frame=None):
+class SubRecordingExtractor(RecordingExtractor):
+    def __init__(self, parent_extractor, *, channel_ids=None, start_frame=None, end_frame=None, epoch_name=None):
         self._parent_extractor=parent_extractor
         self._channel_ids=channel_ids
+        if epoch_name is not None:
+            e_info=parent_extractor.getEpochInfo(epoch_name)
+            e_start=e_info['start_frame']
+            e_end=e_info['end_frame']
+            if start_frame is None:
+                start_frame=e_start
+            else:
+                start_frame=e_start+start_frame
+            if end_frame is None:
+                end_frame=e_end
+            else:
+                end_frame=e_start+end_frame
         self._start_frame=start_frame
         self._end_frame=end_frame
         if self._channel_ids is None:
@@ -16,7 +28,7 @@ class SubInputExtractor(InputExtractor):
         if self._end_frame is None:
             self._end_frame=self._parent_extractor.getNumFrames()
 
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:
@@ -26,7 +38,7 @@ class SubInputExtractor(InputExtractor):
         ch_ids=np.array(self._channel_ids)[channel_ids].tolist()
         sf=self._start_frame+start_frame
         ef=self._start_frame+end_frame
-        return self._parent_extractor.getRawTraces(start_frame=sf,end_frame=ef,channel_ids=ch_ids)
+        return self._parent_extractor.getTraces(start_frame=sf,end_frame=ef,channel_ids=ch_ids)
 
     def getNumChannels(self):
         return len(self._channel_ids)
@@ -43,12 +55,12 @@ class SubInputExtractor(InputExtractor):
     def timeToFrame(self, time):
         return self._parent_extractor.timeToFrame(time)-self._start_frame
 
-    def getRawSnippets(self, snippet_len, center_frames, channel_ids=None):
+    def getSnippets(self, snippet_len, center_frames, channel_ids=None):
         if channel_ids is None:
             channel_ids=range(self.getNumChannels())
         cf=self._start_frame+np.array(center_frames)
         ch_ids=np.array(self._channel_ids)[channel_ids].tolist()
-        return self._parent_extractor.getRawSnippets(snippet_len=snippet_len,center_frames=cf,channel_ids=ch_ids)
+        return self._parent_extractor.getSnippets(snippet_len=snippet_len,center_frames=cf,channel_ids=ch_ids)
 
     def getChannelInfo(self, channel_id):
         ch_id=self._channel_ids[channel_id]

--- a/spikeinterface/SubSortingExtractor.py
+++ b/spikeinterface/SubSortingExtractor.py
@@ -1,11 +1,11 @@
-from abc import ABC, abstractmethod
+from .SortingExtractor import SortingExtractor
 import numpy as np
 
-# Encapsulates a subset of a spike sorting output
+# Encapsulates a subset of a spike sorted data file
 
-class SubOutputExtractor(ABC):
+class SubSortingExtractor(SortingExtractor):
 
-    def __init__(self, parent_extractor, *, unit_ids=None, new_unit_ids=None, start_frame=None, end_frame=None):
+    def __init__(self, parent_extractor, *, total_recording_frames=None, unit_ids=None, new_unit_ids=None, start_frame=None, end_frame=None):
         self._parent_extractor=parent_extractor
         self._unit_ids=unit_ids
         self._new_unit_ids=new_unit_ids
@@ -18,7 +18,10 @@ class SubOutputExtractor(ABC):
         if self._start_frame is None:
             self._start_frame=0
         if self._end_frame is None:
-            self._end_frame=self._parent_extractor.getNumFrames()
+            if(total_recording_frames is None):
+                raise ValueError("Unknown number of frames for this subset of data. Please given either the total recording frames or the specified end_frame")
+            else:
+                self._end_frame=total_recording_frames
         self._original_unit_id_lookup={}
         for i in range(len(self._unit_ids)):
             self._original_unit_id_lookup[self._new_unit_ids[i]]=self._unit_ids[i]
@@ -27,7 +30,11 @@ class SubOutputExtractor(ABC):
         return self._new_unit_ids
 
     def getUnitSpikeTrain(self, unit_id, start_frame=None, end_frame=None):
+        if start_frame is None:
+            start_frame=0
+        if end_frame is None:
+            end_frame=np.Inf
         u=self._original_unit_id_lookup[unit_id]
         sf=self._start_frame+start_frame
         ef=self._end_frame+end_frame
-        return np.array(getUnitSpikeTrain(unit_id=u,start_frame=sf,end_frame=ef))-self._start_frame
+        return self._parent_extractor.getUnitSpikeTrain(unit_id=u,start_frame=sf,end_frame=ef)-self._start_frame

--- a/spikeinterface/__init__.py
+++ b/spikeinterface/__init__.py
@@ -1,10 +1,12 @@
-from .InputExtractor import InputExtractor
-from .OutputExtractor import OutputExtractor
-from .SubInputExtractor import SubInputExtractor
-from .SubOutputExtractor import SubOutputExtractor
+from .RecordingExtractor import RecordingExtractor
+from .SortingExtractor import SortingExtractor
+from .SubSortingExtractor import SubSortingExtractor
+from .SubRecordingExtractor import SubRecordingExtractor
+from .MultiRecordingExtractor import MultiRecordingExtractor
+from .MultiSortingExtractor import MultiSortingExtractor
 
-from .extractors.mdaextractors import MdaInputExtractor, MdaOutputExtractor
-from .extractors.mearecextractors import MEArecInputExtractor, MEArecOutputExtractor
-from .extractors.biocaminputextractor import BiocamInputExtractor
-from .extractors.hs2outputextractor import HS2OutputExtractor
-from .extractors.numpyextractors import NumpyInputExtractor, NumpyOutputExtractor
+from .extractors.mdaextractors.mdaextractors import MdaRecordingExtractor, MdaSortingExtractor
+from .extractors.mearecextractors.mearecextractors import MEArecRecordingExtractor, MEArecSortingExtractor
+from .extractors.biocamrecordingextractor import BiocamRecordingExtractor
+from .extractors.hs2sortingextractor import HS2SortingExtractor
+from .extractors.numpyextractors.numpyextractors import NumpyRecordingExtractor, NumpySortingExtractor

--- a/spikeinterface/extractors/biocaminputextractor/__init__.py
+++ b/spikeinterface/extractors/biocaminputextractor/__init__.py
@@ -1,1 +1,0 @@
-from .biocaminputextractor import BiocamInputExtractor

--- a/spikeinterface/extractors/biocamrecordingextractor/__init__.py
+++ b/spikeinterface/extractors/biocamrecordingextractor/__init__.py
@@ -1,0 +1,1 @@
+from .biocamrecordingextractor import BiocamRecordingExtractor

--- a/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -1,15 +1,13 @@
-from spikeinterface import InputExtractor
-from spikeinterface import OutputExtractor
+from spikeinterface import RecordingExtractor
 
 import numpy as np
 from os.path import join
 import h5py
 import ctypes
 
-
-class BiocamInputExtractor(InputExtractor):
+class BiocamRecordingExtractor(RecordingExtractor):
     def __init__(self, *, dataset_directory, recording_files):
-        InputExtractor.__init__(self)
+        RecordingExtractor.__init__(self)
         self._dataset_directory = dataset_directory
         self._recording_files = recording_files
         if type(recording_files) == list:
@@ -31,7 +29,7 @@ class BiocamInputExtractor(InputExtractor):
     def getSamplingFrequency(self):
         return self._samplingRate
 
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/spikeinterface/extractors/hs2outputextractor/__init__.py
+++ b/spikeinterface/extractors/hs2outputextractor/__init__.py
@@ -1,1 +1,0 @@
-from .hs2outputextractor import HS2OutputExtractor

--- a/spikeinterface/extractors/hs2sortingextractor/__init__.py
+++ b/spikeinterface/extractors/hs2sortingextractor/__init__.py
@@ -1,0 +1,1 @@
+from .hs2sortingextractor import HS2SortingExtractor

--- a/spikeinterface/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeinterface/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -1,5 +1,4 @@
-from spikeinterface import InputExtractor
-from spikeinterface import OutputExtractor
+from spikeinterface import SortingExtractor
 
 import numpy as np
 from os.path import join
@@ -7,9 +6,9 @@ import h5py
 import ctypes
 
 
-class HS2OutputExtractor(OutputExtractor):
+class HS2SortingExtractor(SortingExtractor):
     def __init__(self, *, dataset_directory, recording_files):
-        OutputExtractor.__init__(self)
+        SortingExtractor.__init__(self)
         self._dataset_directory = dataset_directory
         self._recording_files = recording_files
         if type(recording_files) == list:

--- a/spikeinterface/extractors/mdaextractors/__init__.py
+++ b/spikeinterface/extractors/mdaextractors/__init__.py
@@ -1,1 +1,1 @@
-from .mdaextractors import MdaInputExtractor, MdaOutputExtractor
+from .mdaextractors import MdaRecordingExtractor, MdaSortingExtractor

--- a/spikeinterface/extractors/mdaextractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors/mdaextractors.py
@@ -1,14 +1,14 @@
-from spikeinterface import InputExtractor
-from spikeinterface import OutputExtractor
+from spikeinterface import RecordingExtractor
+from spikeinterface import SortingExtractor
 
 from mountainlab_pytools import mlproc as mlp
 from mountainlab_pytools import mdaio
 import os, json
 import numpy as np
 
-class MdaInputExtractor(InputExtractor):
+class MdaRecordingExtractor(RecordingExtractor):
     def __init__(self, *, dataset_directory, download=True):
-        InputExtractor.__init__(self)
+        RecordingExtractor.__init__(self)
         self._dataset_directory=dataset_directory
         timeseries0=dataset_directory+'/raw.mda'
         self._dataset_params=read_dataset_params(dataset_directory)
@@ -40,7 +40,7 @@ class MdaInputExtractor(InputExtractor):
     def getSamplingFrequency(self):
         return self._samplerate
         
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:
@@ -58,31 +58,31 @@ class MdaInputExtractor(InputExtractor):
         )
 
     @staticmethod
-    def writeDataset(input_extractor,output_dirname):
-        M=input_extractor.getNumChannels()
-        N=input_extractor.getNumFrames()
+    def writeRecordedData(recording_extractor,output_dirname):
+        M=recording_extractor.getNumChannels()
+        N=recording_extractor.getNumFrames()
         channel_ids=range(M)
-        raw=input_extractor.getRawTraces()
-        info0=input_extractor.getChannelInfo(channel_ids[0])
+        raw=recording_extractor.getTraces()
+        info0=recording_extractor.getChannelInfo(channel_ids[0])
         nd=len(info0['location'])
         geom=np.zeros((M,nd))
         for ii in range(len(channel_ids)):
-            info0=input_extractor.getChannelInfo(channel_ids[ii])
+            info0=recording_extractor.getChannelInfo(channel_ids[ii])
             geom[ii,:]=list(info0['location'])
         if not os.path.exists(output_dirname):
             os.mkdir(output_dirname)
         mdaio.writemda32(raw,output_dirname+'/raw.mda')
         params=dict(
-            samplerate=input_extractor.getSamplingFrequency(),
+            samplerate=recording_extractor.getSamplingFrequency(),
             spike_sign=-1
         )
         with open(output_dirname+'/params.json','w') as f:
             json.dump(params,f)
         np.savetxt(output_dirname+'/geom.csv', geom, delimiter=',')
 
-class MdaOutputExtractor(OutputExtractor):
+class MdaSortingExtractor(SortingExtractor):
     def __init__(self, *, firings_file):
-        OutputExtractor.__init__(self)
+        SortingExtractor.__init__(self)
         verbose=is_url(firings_file)
         if verbose:
             print('Downloading file if needed: '+firings_file)
@@ -92,7 +92,7 @@ class MdaOutputExtractor(OutputExtractor):
         self._firings=mdaio.readmda(self._firings_path)
         self._times=self._firings[1,:]
         self._labels=self._firings[2,:]
-        self._unit_ids=np.unique(self._labels)
+        self._unit_ids=np.unique(self._labels).astype(int)
         
     def getUnitIds(self):
         return self._unit_ids
@@ -106,14 +106,14 @@ class MdaOutputExtractor(OutputExtractor):
         return self._times[inds]
     
     @staticmethod
-    def writeFirings(output_extractor,firings_out):
-        unit_ids=output_extractor.getUnitIds()
+    def writeSortedData(sorting_extractor,firings_out):
+        unit_ids=sorting_extractor.getUnitIds()
         K=np.max(unit_ids)
         times_list=[]
         labels_list=[]
         for i in range(len(unit_ids)):
             unit=unit_ids[i]
-            times=output_extractor.getUnitSpikeTrain(unit_id=unit)
+            times=sorting_extractor.getUnitSpikeTrain(unit_id=unit)
             times_list.append(times)
             labels_list.append(np.ones(times.shape)*unit)
         all_times=np.concatenate(times_list)

--- a/spikeinterface/extractors/mearecextractors/__init__.py
+++ b/spikeinterface/extractors/mearecextractors/__init__.py
@@ -1,1 +1,1 @@
-from .mearecextractors import MEArecInputExtractor, MEArecOutputExtractor
+from .mearecextractors import MEArecRecordingExtractor, MEArecSortingExtractor

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -1,14 +1,14 @@
-from spikeinterface import InputExtractor
-from spikeinterface import OutputExtractor
+from spikeinterface import RecordingExtractor
+from spikeinterface import SortingExtractor
 
 import quantities as pq
 import numpy as np
 from os.path import join
 import h5py
 
-class MEArecInputExtractor(InputExtractor):
+class MEArecRecordingExtractor(RecordingExtractor):
     def __init__(self, *, recording_folder=None, recording_file=None):
-        InputExtractor.__init__(self)
+        RecordingExtractor.__init__(self)
         self._recording_folder = recording_folder
         self._recording_file = recording_file
         self._fs = None
@@ -37,7 +37,7 @@ class MEArecInputExtractor(InputExtractor):
             self._initialize()
         return self._fs
         
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if self._recordings is None:
             self._initialize()
         if start_frame is None:
@@ -55,9 +55,9 @@ class MEArecInputExtractor(InputExtractor):
             location=self._positions[channel_id,:]
         )
 
-class MEArecOutputExtractor(OutputExtractor):
+class MEArecSortingExtractor(SortingExtractor):
     def __init__(self, *, recording_folder=None, recording_file=None):
-        OutputExtractor.__init__(self)
+        SortingExtractor.__init__(self)
         self._recording_folder = recording_folder
         self._recording_file = recording_file
         self._num_units = None

--- a/spikeinterface/extractors/numpyextractors/__init__.py
+++ b/spikeinterface/extractors/numpyextractors/__init__.py
@@ -1,1 +1,1 @@
-from .numpyextractors import NumpyInputExtractor, NumpyOutputExtractor
+from .numpyextractors import NumpyRecordingExtractor, NumpySortingExtractor

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -1,11 +1,11 @@
-from spikeinterface import InputExtractor
-from spikeinterface import OutputExtractor
+from spikeinterface import RecordingExtractor
+from spikeinterface import SortingExtractor
 
 import numpy as np
 
-class NumpyInputExtractor(InputExtractor):
+class NumpyRecordingExtractor(RecordingExtractor):
     def __init__(self, *, timeseries, samplerate, geom=None):
-        InputExtractor.__init__(self)
+        RecordingExtractor.__init__(self)
         self._timeseries=timeseries
         self._samplerate=samplerate
         self._geom=geom
@@ -19,7 +19,7 @@ class NumpyInputExtractor(InputExtractor):
     def getSamplingFrequency(self):
         return self._samplerate
         
-    def getRawTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:
@@ -34,16 +34,16 @@ class NumpyInputExtractor(InputExtractor):
             location=self._geom[channel_id,:]
         )
 
-class NumpyOutputExtractor(OutputExtractor):
+class NumpySortingExtractor(SortingExtractor):
     def __init__(self):
-        OutputExtractor.__init__(self)
+        SortingExtractor.__init__(self)
         self._unit_ids=[]
         self._units={}
 
-    def loadFromExtractor(output_extractor):
-        ids=output_extractor.getUnitIds()
+    def loadFromExtractor(sorting_extractor):
+        ids=sorting_extractor.getUnitIds()
         for id in ids:
-            self.addUnit(id,output_extractor.getUnitSpikeTrain(id))
+            self.addUnit(id,sorting_extractor.getUnitSpikeTrain(id))
 
     def setTimesLabels(self,times,labels):
         units=np.sort(np.unique(labels))

--- a/tests/test_mda_extractors.py
+++ b/tests/test_mda_extractors.py
@@ -77,9 +77,9 @@ class TestMdaExtractors(unittest.TestCase):
     def test_sorting_extractor(self):
         K=self.dataset['num_units']
         # getUnitIds
-        self.assertEqual(np.array(self.OX.getUnitIds()).tolist(),list(range(1,K+1)))
+        self.assertEqual(np.array(self.SX.getUnitIds()).tolist(),list(range(1,K+1)))
         # getUnitSpikeTrain
-        st=self.OX.getUnitSpikeTrain(unit_id=1)
+        st=self.SX.getUnitSpikeTrain(unit_id=1)
         inds=np.where(self.dataset['labels']==1)[0]
         st2=self.dataset['times'][inds]
         self.assertTrue(np.allclose(st,st2))

--- a/tests/test_mda_extractors.py
+++ b/tests/test_mda_extractors.py
@@ -16,8 +16,8 @@ class TestMdaExtractors(unittest.TestCase):
         # Create a temporary directory
         self.test_dir = tempfile.mkdtemp()
         self._create_dataset()
-        self.IX=si.MdaInputExtractor(dataset_directory=self.test_dir+'/dataset')
-        self.OX=si.MdaOutputExtractor(firings_file=self.test_dir+'/dataset/firings_true.mda')
+        self.RX=si.MdaRecordingExtractor(dataset_directory=self.test_dir+'/dataset')
+        self.SX=si.MdaSortingExtractor(firings_file=self.test_dir+'/dataset/firings_true.mda')
         
     def tearDown(self):
         # Remove the directory after the test
@@ -54,27 +54,27 @@ class TestMdaExtractors(unittest.TestCase):
         
         np.savetxt(self.test_dir+'/dataset/geom.csv', self.dataset['geom'], delimiter=',')
      
-    def test_input_extractor(self):
+    def test_recording_extractor(self):
         X=self.dataset['raw']
         # getNumChannels
-        self.assertEqual(self.IX.getNumChannels(),self.dataset['num_channels'])
+        self.assertEqual(self.RX.getNumChannels(),self.dataset['num_channels'])
         # getNumFrames
-        self.assertEqual(self.IX.getNumFrames(),self.dataset['num_timepoints'])
+        self.assertEqual(self.RX.getNumFrames(),self.dataset['num_timepoints'])
         # getSamplingFrequency
-        self.assertEqual(self.IX.getSamplingFrequency(),30000)
-        # getRawTraces
-        self.assertTrue(np.allclose(self.IX.getRawTraces(),X))
-        self.assertTrue(np.allclose(self.IX.getRawTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),X[[0,3],0:12]))
+        self.assertEqual(self.RX.getSamplingFrequency(),30000)
+        # getTraces
+        self.assertTrue(np.allclose(self.RX.getTraces(),X))
+        self.assertTrue(np.allclose(self.RX.getTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),X[[0,3],0:12]))
         # getChannelInfo
-        self.assertTrue(np.allclose(np.array(self.IX.getChannelInfo(channel_id=1)['location']),self.dataset['geom'][1,:]))
+        self.assertTrue(np.allclose(np.array(self.RX.getChannelInfo(channel_id=1)['location']),self.dataset['geom'][1,:]))
         # timeToFrame / frameToTime
-        self.assertEqual(self.IX.timeToFrame(12),12*self.IX.getSamplingFrequency())
-        self.assertEqual(self.IX.frameToTime(12),12/self.IX.getSamplingFrequency())
-        # getRawSnippets
-        snippets=self.IX.getRawSnippets(snippet_len=20,center_frames=[0,30,50])
+        self.assertEqual(self.RX.timeToFrame(12),12*self.RX.getSamplingFrequency())
+        self.assertEqual(self.RX.frameToTime(12),12/self.RX.getSamplingFrequency())
+        # getSnippets
+        snippets=self.RX.getSnippets(snippet_len=20,center_frames=[0,30,50])
         self.assertTrue(np.allclose(snippets[1],X[:,20:40]))
     
-    def test_output_extractor(self):
+    def test_sorting_extractor(self):
         K=self.dataset['num_units']
         # getUnitIds
         self.assertEqual(np.array(self.OX.getUnitIds()).tolist(),list(range(1,K+1)))

--- a/tests/test_mearec_extractors.py
+++ b/tests/test_mearec_extractors.py
@@ -18,8 +18,8 @@ class TestMearecExtractors(unittest.TestCase):
         # Create a temporary directory
         self.test_dir = tempfile.mkdtemp()
         self._create_dataset()
-        self.IX=si.MEArecInputExtractor(recording_folder=self.test_dir+'/recordings')
-        self.OX=si.MEArecOutputExtractor(recording_folder=self.test_dir+'/recordings')
+        self.RX=si.MEArecRecordingExtractor(recording_folder=self.test_dir+'/recordings')
+        self.SX=si.MEArecSortingExtractor(recording_folder=self.test_dir+'/recordings')
         
     def tearDown(self):
         # Remove the directory after the test
@@ -77,26 +77,26 @@ class TestMearecExtractors(unittest.TestCase):
             yaml.dump(info, f)
 
      
-    def test_input_extractor(self):
+    def test_recording_extractor(self):
         X=self.dataset['recordings']
         # getNumChannels
-        self.assertEqual(self.IX.getNumChannels(),self.dataset['num_channels'])
+        self.assertEqual(self.RX.getNumChannels(),self.dataset['num_channels'])
         # getNumFrames
-        self.assertEqual(self.IX.getNumFrames(),self.dataset['num_timepoints'])
+        self.assertEqual(self.RX.getNumFrames(),self.dataset['num_timepoints'])
         # getSamplingFrequency
-        self.assertEqual(self.IX.getSamplingFrequency(),30000)
-        # getRawTraces
-        self.assertTrue(np.allclose(self.IX.getRawTraces(),X))
-        self.assertTrue(np.allclose(self.IX.getRawTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),X[[0,3],0:12]))
+        self.assertEqual(self.RX.getSamplingFrequency(),30000)
+        # getTraces
+        self.assertTrue(np.allclose(self.RX.getTraces(),X))
+        self.assertTrue(np.allclose(self.RX.getTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),X[[0,3],0:12]))
         # getChannelInfo
-        self.assertTrue(np.allclose(np.array(self.IX.getChannelInfo(channel_id=1)['location']),self.dataset['positions'][1,:]))
+        self.assertTrue(np.allclose(np.array(self.RX.getChannelInfo(channel_id=1)['location']),self.dataset['positions'][1,:]))
     
-    def test_output_extractor(self):
+    def test_sorting_extractor(self):
         K=self.dataset['num_units']
         # getUnitIds
-        self.assertEqual(self.OX.getUnitIds(), range(0,K))
+        self.assertEqual(self.SX.getUnitIds(), range(0,K))
         # getUnitSpikeTrain
-        st = self.OX.getUnitSpikeTrain(unit_id=1)
+        st = self.SX.getUnitSpikeTrain(unit_id=1)
         st2 = (self.dataset['spiketrains'][1].times.rescale('s') * self.dataset['fs'].rescale('Hz')).magnitude
         self.assertTrue(np.allclose(st,st2))
     #

--- a/tests/test_numpy_extractors.py
+++ b/tests/test_numpy_extractors.py
@@ -17,42 +17,42 @@ class TestNumpyExtractors(unittest.TestCase):
         self._X=X
         self._geom=geom
         self._samplerate=samplerate
-        self.IX=si.NumpyInputExtractor(timeseries=X,samplerate=samplerate,geom=geom)
-        self.OX=si.NumpyOutputExtractor()
+        self.RX=si.NumpyRecordingExtractor(timeseries=X,samplerate=samplerate,geom=geom)
+        self.SX=si.NumpySortingExtractor()
         L=200
         self._train1=np.random.uniform(0,N,L)
-        self.OX.addUnit(unit_id=1,times=self._train1)
-        self.OX.addUnit(unit_id=2,times=np.random.uniform(0,N,L))
-        self.OX.addUnit(unit_id=3,times=np.random.uniform(0,N,L))
+        self.SX.addUnit(unit_id=1,times=self._train1)
+        self.SX.addUnit(unit_id=2,times=np.random.uniform(0,N,L))
+        self.SX.addUnit(unit_id=3,times=np.random.uniform(0,N,L))
         
     def tearDown(self):
         pass
      
-    def test_input_extractor(self):
+    def test_recording_extractor(self):
         # getNumChannels
-        self.assertEqual(self.IX.getNumChannels(),self._X.shape[0])
+        self.assertEqual(self.RX.getNumChannels(),self._X.shape[0])
         # getNumFrames
-        self.assertEqual(self.IX.getNumFrames(),self._X.shape[1])
+        self.assertEqual(self.RX.getNumFrames(),self._X.shape[1])
         # getSamplingFrequency
-        self.assertEqual(self.IX.getSamplingFrequency(),self._samplerate)
-        # getRawTraces
-        self.assertTrue(np.allclose(self.IX.getRawTraces(),self._X))
-        self.assertTrue(np.allclose(self.IX.getRawTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),self._X[[0,3],0:12]))
+        self.assertEqual(self.RX.getSamplingFrequency(),self._samplerate)
+        # getTraces
+        self.assertTrue(np.allclose(self.RX.getTraces(),self._X))
+        self.assertTrue(np.allclose(self.RX.getTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),self._X[[0,3],0:12]))
         # getChannelInfo
-        self.assertTrue(np.allclose(np.array(self.IX.getChannelInfo(channel_id=1)['location']),self._geom[1,:]))
+        self.assertTrue(np.allclose(np.array(self.RX.getChannelInfo(channel_id=1)['location']),self._geom[1,:]))
         # timeToFrame / frameToTime
-        self.assertEqual(self.IX.timeToFrame(12),12*self.IX.getSamplingFrequency())
-        self.assertEqual(self.IX.frameToTime(12),12/self.IX.getSamplingFrequency())
-        # getRawSnippets
-        snippets=self.IX.getRawSnippets(snippet_len=20,center_frames=[0,30,50])
+        self.assertEqual(self.RX.timeToFrame(12),12*self.RX.getSamplingFrequency())
+        self.assertEqual(self.RX.frameToTime(12),12/self.RX.getSamplingFrequency())
+        # getSnippets
+        snippets=self.RX.getSnippets(snippet_len=20,center_frames=[0,30,50])
         self.assertTrue(np.allclose(snippets[1],self._X[:,20:40]))
     
-    def test_output_extractor(self):
+    def test_sorting_extractor(self):
         unit_ids=[1,2,3]
         # getUnitIds
-        self.assertEqual(self.OX.getUnitIds(),unit_ids)
+        self.assertEqual(self.SX.getUnitIds(),unit_ids)
         # getUnitSpikeTrain
-        st=self.OX.getUnitSpikeTrain(unit_id=1)
+        st=self.SX.getUnitSpikeTrain(unit_id=1)
         self.assertTrue(np.allclose(st,self._train1))
  
 if __name__ == '__main__':


### PR DESCRIPTION
_* = Controversial and worth evaluating

Module: InputExtractor 
- InputExtractor --> RecordingExtractor
- *getEpochNames throws a not implemented error rather than returning an empty list
- *writeInput --> writeRecordedData
- getRawTraces --> getTraces
- getRawSnippets --> getSnippets

Module: SubInputExtractor
- SubInputExtractor --> SubRecordingExtractor

Module: MultiInputExtractor
- MultiInputExtractor --> MultiRecordingExtractor
- import spikeinterface as si --> from .RecordingExtractor import RecordingExtractor
- input_extractors --> recording_extractors

Module: OutputExtractor
- OutputExtractor  --> SortingExtractor
- *writeOutput --> writeSortedData

Module:SubOutputExtractor
- Made SubSortingExtractor a SortingExtractor object rather than an ABC object.
- *total_recording_frames added to SubOutputExtractor to replace need for RecordingExtractor. Throws value error if neither total_recording_frames or an end_frame is given.
- Current implementation appeared to be broken since the parent extractor was calling getUnitIds and also getNumFrames which would be neither a Recording or Sorting extractor.


Changed all examples and tests to reflect these changes. Currently, only two examples works as spikewidgets must be changed to reflect new changes and the biocam data requires access to a dataset the user won't have.

We also need unit tests for the Multi and subextractors since I am not confident they will all pass yet.