### PR TITLE
Added getUnitProperty to the sorting extractor.

### DIFF
--- a/spikeinterface/SortingExtractor.py
+++ b/spikeinterface/SortingExtractor.py
@@ -54,6 +54,25 @@ class SortingExtractor(ABC):
         '''
         pass
 
+    def getUnitProperty(self, unit_id, property):
+        '''This function returns a property of a specified unit. It is a static
+        method so it can be used without instantiating this sorting extractor.
+
+        Parameters
+        ----------
+        unit_id: int
+            The id that specifies a unit in the recording.
+        property: string
+            The property requested from the extractor. Note individual extractors provide different properties.
+        Returns
+        ----------
+        data: numpy.ndarray
+            A numpy array containing the requested property.
+        '''
+        raise NotImplementedError("The getUnitProperty function is not \
+                                  implemented for this extractor")
+
+
     @staticmethod
     def writeSorting(self, sorting_extractor, save_path):
         '''This function writes out the spike sorted data file of a given sorting

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -9,16 +9,16 @@ class NumpyRecordingExtractor(RecordingExtractor):
         self._timeseries=timeseries
         self._samplerate=float(samplerate)
         self._geom=geom
-        
+
     def getNumChannels(self):
         return self._timeseries.shape[0]
-    
+
     def getNumFrames(self):
         return self._timeseries.shape[1]
-    
+
     def getSamplingFrequency(self):
         return self._samplerate
-        
+
     def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
         if start_frame is None:
             start_frame=0
@@ -28,7 +28,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
             channel_ids=range(self.getNumChannels())
         recordings=self._timeseries[:,start_frame:end_frame][channel_ids,:]
         return recordings
-    
+
     def getChannelInfo(self, channel_id):
         return dict(
             location=self._geom[channel_id,:]
@@ -39,6 +39,7 @@ class NumpySortingExtractor(SortingExtractor):
         SortingExtractor.__init__(self)
         self._unit_ids=[]
         self._units={}
+        self._properties = {}
 
     def loadFromExtractor(sorting_extractor):
         ids=sorting_extractor.getUnitIds()
@@ -54,7 +55,7 @@ class NumpySortingExtractor(SortingExtractor):
     def addUnit(self,unit_id,times):
         self._unit_ids.append(unit_id)
         self._units[unit_id]=dict(times=times)
-        
+
     def getUnitIds(self):
         return self._unit_ids
 
@@ -66,3 +67,15 @@ class NumpySortingExtractor(SortingExtractor):
         times=self._units[unit_id]['times']
         inds=np.where((start_frame<=times)&(times<end_frame))[0]
         return times[inds]
+
+    def setUnitProperty(self, key, data):
+        assert data.shape[0] == len(self.getUnitIds()), "Data size does not match unit size"
+        self._properties[key] = data
+
+    def getUnitProperty(self, unit_id, property):
+        assert len(self._properties)>0, "No properties defined"
+        try:
+            data = self._properties[property][unit_id]
+        except:
+            raise Exception("Wrong property key. Valid keys are:\n"+"\n".join("{} ".format(k) for k in self._properties.keys()))
+        return data

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -39,7 +39,7 @@ class NumpySortingExtractor(SortingExtractor):
         SortingExtractor.__init__(self)
         self._unit_ids=[]
         self._units={}
-        self._properties = {}
+        # self._properties = {}
 
     def loadFromExtractor(sorting_extractor):
         ids=sorting_extractor.getUnitIds()
@@ -70,12 +70,13 @@ class NumpySortingExtractor(SortingExtractor):
 
     def setUnitProperty(self, key, data):
         assert data.shape[0] == len(self.getUnitIds()), "Data size does not match unit size"
-        self._properties[key] = data
+        for i,d in enumerate(data):
+            self._units[self.getUnitIds()[i]][key] = d
 
     def getUnitProperty(self, unit_id, property):
-        assert len(self._properties)>0, "No properties defined"
+        # assert len(self._properties)>0, "No properties defined"
         try:
-            data = self._properties[property][unit_id]
+            data = self._units[unit_id][property]
         except:
-            raise Exception("Wrong property key. Valid keys are:\n"+"\n".join("{} ".format(k) for k in self._properties.keys()))
+            raise Exception("Wrong property key. Valid keys are:\n"+"\n".join("{} ".format(k) for k in self._units[self.getUnitIds()[0]].keys()))
         return data

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -8,12 +8,12 @@ def append_to_path(dir0): # A convenience function
         sys.path.append(dir0)
 append_to_path(os.getcwd()+'/..')
 import spikeinterface as si
- 
+
 class TestExtractors(unittest.TestCase):
     def setUp(self):
         self.RX, self.SX, self.example_info = self._create_example()
         self.test_dir = tempfile.mkdtemp()
-        
+
     def tearDown(self):
         # Remove the directory after the test
         shutil.rmtree(self.test_dir)
@@ -48,7 +48,7 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(self.SX.getUnitIds(),self.example_info['unit_ids'])
         self.assertTrue(np.allclose(self.SX.getUnitSpikeTrain(1),self.example_info['train1']))
         self._check_recording_return_types(self.RX)
-     
+
     def test_mda_extractor(self):
         path1=self.test_dir+'/mda'
         path2=path1+'/firings_true.mda'
@@ -148,6 +148,6 @@ class TestExtractors(unittest.TestCase):
             train1=np.sort(SX1.getUnitSpikeTrain(id))
             train2=np.sort(SX2.getUnitSpikeTrain(id))
             self.assertTrue(np.allclose(train1,train2))
- 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Purpose of this functionality is to retrieve information about sorted units, such as spike or unit locations.
The interface is based on dictionary keys, and information is stored in a dictionary within each class.

Added functionality to  read info to the HS2 sorting extractor, and to both write and read to the numpy class.

From the HS2 extractor, one can now obtain unit locations ``HS2e.getUnitProperty(u,'unit_location')`` and ``HS2e.getUnitProperty(u,'spike_locations')``

The numpy extractor also allows writing this info, e.g. ``NPe.setUnitProperty('a_new_property', data)``.

I'm neither sure about this implementation, nor about the naming, open for suggestions.