### PR TITLE
All spike trains returned as integers. Tests adjusted to look for this

### DIFF
--- a/examples/getting_started_with_sorting_extractors.ipynb
+++ b/examples/getting_started_with_sorting_extractors.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,9 +53,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unit ids = [1, 2, 3, 4]\n",
+      "Num. events for unit 1 = 252\n",
+      "Num. events for first second of unit 1 = 8\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate the API for extracting information\n",
     "print('Unit ids = {}'.format(SX.getUnitIds()))\n",
@@ -67,9 +77,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "writeRecording() got an unexpected keyword argument 'recording'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-54f3118943e8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Write the input/output in the MountainSort format\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0msi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mMdaRecordingExtractor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwriteRecording\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrecording\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mRX\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0msave_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'sample_mountainsort_dataset'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0msi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mMdaSortingExtractor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwriteSorting\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msorting\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mSX\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0msave_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'sample_mountainsort_dataset/firings_true.mda'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: writeRecording() got an unexpected keyword argument 'recording'"
+     ]
+    }
+   ],
    "source": [
     "# Write the input/output in the MountainSort format\n",
     "si.MdaRecordingExtractor.writeRecording(recording=RX,save_path='sample_mountainsort_dataset')\n",

--- a/spikeinterface/extractors/mdaextractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors/mdaextractors.py
@@ -105,7 +105,7 @@ class MdaSortingExtractor(SortingExtractor):
         if end_frame is None:
             end_frame=np.Inf
         inds=np.where((self._labels==unit_id)&(start_frame<=self._times)&(self._times<end_frame))
-        return self._times[inds]
+        return np.rint(self._times[inds]).astype(int)
 
     @staticmethod
     def writeSorting(sorting,save_path):

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -123,7 +123,7 @@ class MEArecSortingExtractor(SortingExtractor):
         times = (self._spike_trains[self.getUnitIds().index(unit_id)].times.rescale('s') *
                  self._fs.rescale('Hz')).magnitude
         inds = np.where((start_frame<=times)&(times<end_frame))
-        return times[inds]
+        return np.rint(times[inds]).astype(int)
 
     @staticmethod
     def writeSorting(sorting, save_path, sampling_frequency):

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -64,4 +64,4 @@ class NumpySortingExtractor(SortingExtractor):
             end_frame=np.Inf
         times=self._units[unit_id]['times']
         inds=np.where((start_frame<=times)&(times<end_frame))[0]
-        return times[inds]
+        return np.rint(times[inds]).astype(int)

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -28,7 +28,7 @@ class TestExtractors(unittest.TestCase):
         RX=si.NumpyRecordingExtractor(timeseries=X,samplerate=samplerate,geom=geom)
         SX=si.NumpySortingExtractor()
         L=[200, 300, 400]
-        train1 = np.random.uniform(0,N,L[0])
+        train1 = np.rint(np.random.uniform(0,N,L[0])).astype(int)
         SX.addUnit(unit_id=1,times=train1)
         SX.addUnit(unit_id=2,times=np.random.uniform(0,N,L[1]))
         SX.addUnit(unit_id=3,times=np.random.uniform(0,N,L[2]))
@@ -52,7 +52,8 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(self.SX.getUnitIds(),self.example_info['unit_ids'])
         self.assertEqual(self.RX.getChannelProperty(channel_id=0, property_name='location'),self.example_info['channel_prop'])
         self.assertEqual(self.SX.getUnitProperty(unit_id=1, property_name='stablility'),self.example_info['unit_prop'])
-        self.assertTrue(np.allclose(self.SX.getUnitSpikeTrain(1),self.example_info['train1']))
+        self.assertTrue(np.array_equal(self.SX.getUnitSpikeTrain(1),self.example_info['train1']))
+        self.assertTrue(issubclass(self.SX.getUnitSpikeTrain(1).dtype.type, np.integer))
         self._check_recording_return_types(self.RX)
 
     def test_mda_extractor(self):
@@ -151,10 +152,11 @@ class TestExtractors(unittest.TestCase):
 
     def _check_sorting_return_types(self,SX):
         unit_ids=SX.getUnitIds()
-        self.assertTrue(all(isinstance(id, int) or isinstance(id, np.int64) for id in unit_ids))
+        self.assertTrue(all(isinstance(id, int) or isinstance(id, np.integer) for id in unit_ids))
         for id in unit_ids:
             train=SX.getUnitSpikeTrain(id)
-            self.assertTrue(all(isinstance(x, float) or isinstance(x, np.float64) for x in train))
+            print(train)
+            self.assertTrue(all(isinstance(x, int) or isinstance(x, np.integer) for x in train))
 
     def _check_sortings_equal(self,SX1,SX2):
         K=len(SX1.getUnitIds())
@@ -165,7 +167,9 @@ class TestExtractors(unittest.TestCase):
         for id in ids1:
             train1=np.sort(SX1.getUnitSpikeTrain(id))
             train2=np.sort(SX2.getUnitSpikeTrain(id))
-            self.assertTrue(np.allclose(train1,train2))
+            print(train1)
+            print(train2)
+            self.assertTrue(np.array_equal(train1,train2))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_numpy_extractors.py
+++ b/tests/test_numpy_extractors.py
@@ -20,7 +20,7 @@ class TestNumpyExtractors(unittest.TestCase):
         self.RX=si.NumpyRecordingExtractor(timeseries=X,samplerate=samplerate,geom=geom)
         self.SX=si.NumpySortingExtractor()
         L=200
-        self._train1=np.random.uniform(0,N,L)
+        self._train1=np.rint(np.random.uniform(0,N,L)).astype(int)
         self.SX.addUnit(unit_id=1,times=self._train1)
         self.SX.addUnit(unit_id=2,times=np.random.uniform(0,N,L))
         self.SX.addUnit(unit_id=3,times=np.random.uniform(0,N,L))


### PR DESCRIPTION
Adjusted all extractors and tests to return integers in the spike trains. All algorithms that have times go through this procedure:

np.rint(times).astype(int).

If this is desired, we can merge this with master since all the tests pass.