### PR TITLE
Added getChannelIds and updated probe file handling

### DIFF
--- a/spikeinterface/MultiRecordingExtractor.py
+++ b/spikeinterface/MultiRecordingExtractor.py
@@ -83,9 +83,6 @@ class MultiRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._num_channels))
 
-    def getNumChannels(self):
-        return self._num_channels
-
     def getNumFrames(self):
         return self._num_frames
 

--- a/spikeinterface/MultiRecordingExtractor.py
+++ b/spikeinterface/MultiRecordingExtractor.py
@@ -80,6 +80,9 @@ class MultiRecordingExtractor(RecordingExtractor):
         )
         return np.concatenate(list,axis=1)
 
+    def getChannelIds(self):
+        return list(range(self._num_channels))
+
     def getNumChannels(self):
         return self._num_channels
 

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -50,17 +50,6 @@ class RecordingExtractor(ABC):
         pass
 
     @abstractmethod
-    def getNumChannels(self):
-        '''This function returns the number of channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Number of channels in the recording.
-        '''
-        pass
-
-    @abstractmethod
     def getNumFrames(self):
         '''This function returns the number of frames in the recording.
 
@@ -93,6 +82,19 @@ class RecordingExtractor(ABC):
 
         '''
         pass
+
+
+    def getNumChannels(self):
+        '''This function returns the number of channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Number of channels in the recording.
+        '''
+        print('WARNING: this is a temporary warning. You should use getChannelIds() to iterate through the channels. '
+              'This warning will be removed in future versions of SpikeInterface.')
+        return len(self.getChannelIds())
 
     def frameToTime(self, frame):
         '''This function converts a user-inputted frame index to a time with units of seconds.

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -12,7 +12,6 @@ class RecordingExtractor(ABC):
     def __init__(self):
         self._epochs = {}
         self._channel_properties = {}
-        self._channel_ids = None
 
     @abstractmethod
     def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
@@ -83,6 +82,7 @@ class RecordingExtractor(ABC):
         '''
         pass
 
+    @abstractmethod
     def getChannelIds(self):
         '''Returns the list of channel ids. If not specified, the range from 0 to num_channels - 1 is returned.
 
@@ -92,10 +92,7 @@ class RecordingExtractor(ABC):
             Channel list
 
         '''
-        if self._channel_ids is None:
-            return list(range(self.getNumChannels()))
-        else:
-            return self._channel_ids
+        pass
 
     def frameToTime(self, frame):
         '''This function converts a user-inputted frame index to a time with units of seconds.

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -84,10 +84,12 @@ class RecordingExtractor(ABC):
         pass
 
     def getChannelIds(self):
-        '''
+        '''Returns the list of channel ids. If not specified, the range from 0 to num_channels - 1 is returned.
 
         Returns
         -------
+        channel_ids: list
+            Channel list
 
         '''
         if self._channel_ids is None:

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -12,6 +12,7 @@ class RecordingExtractor(ABC):
     def __init__(self):
         self._epochs = {}
         self._channel_properties = {}
+        self._channel_ids = None
 
     @abstractmethod
     def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
@@ -81,6 +82,18 @@ class RecordingExtractor(ABC):
             Sampling frequency of the recordings in Hz.
         '''
         pass
+
+    def getChannelIds(self):
+        '''
+
+        Returns
+        -------
+
+        '''
+        if self._channel_ids is None:
+            return list(range(self.getNumChannels()))
+        else:
+            return self._channel_ids
 
     def frameToTime(self, frame):
         '''This function converts a user-inputted frame index to a time with units of seconds.
@@ -190,7 +203,7 @@ class RecordingExtractor(ABC):
             The data associated with the given property name. Could be many
             formats as specified by the user.
         '''
-        if(isinstance(channel_id, int)):
+        if(isinstance(channel_id, (int, np.integer))):
             if(channel_id in range(self.getNumChannels())):
                 if channel_id not in self._channel_properties:
                     self._channel_properties[channel_id]={}
@@ -220,7 +233,7 @@ class RecordingExtractor(ABC):
             The data associated with the given property name. Could be many
             formats as specified by the user.
         '''
-        if(isinstance(channel_id, int)):
+        if(isinstance(channel_id, (int, np.integer))):
             if(channel_id in range(self.getNumChannels())):
                 if channel_id not in self._channel_properties:
                     self._channel_properties[channel_id]={}

--- a/spikeinterface/SortingExtractor.py
+++ b/spikeinterface/SortingExtractor.py
@@ -114,7 +114,7 @@ class SortingExtractor(ABC):
             The data associated with the given property name. Could be many
             formats as specified by the user.
         '''
-        if (isinstance(unit_id, int)) or (isinstance(unit_id, np.int64)):
+        if isinstance(unit_id, (int, np.integer)):
             if(unit_id in self.getUnitIds()):
                 if unit_id not in self._unit_properties:
                     self._unit_properties[unit_id]={}
@@ -160,7 +160,7 @@ class SortingExtractor(ABC):
             formats as specified by the user.
         '''
         print('WARNING: addUnitProperty is deprecated. Use setUnitProperty instead.')
-        if (isinstance(unit_id, int)) or (isinstance(unit_id, np.int64)):
+        if isinstance(unit_id, (int, np.integer)):
             if(unit_id in self.getUnitIds()):
                 if(isinstance(property_name, str)):
                     self._unit_properties[unit_id][property_name] = value
@@ -187,7 +187,7 @@ class SortingExtractor(ABC):
             The data associated with the given property name. Could be many
             formats as specified by the user.
         '''
-        if (isinstance(unit_id, int)) or (isinstance(unit_id, np.int64)):
+        if isinstance(unit_id, (int, np.integer)):
             if(unit_id in self.getUnitIds()):
                 if unit_id not in self._unit_properties:
                     self._unit_properties[unit_id]={}
@@ -245,7 +245,7 @@ class SortingExtractor(ABC):
                     property_names.append(curr_property_name)
             property_names = sorted(list(set(property_names)))
             return property_names
-        if (isinstance(unit_id, int)) or (isinstance(unit_id, np.int64)):
+        if isinstance(unit_id, (int, np.integer)):
             if(unit_id in self.getUnitIds()):
                 if unit_id not in self._unit_properties:
                     self._unit_properties[unit_id]={}

--- a/spikeinterface/SubRecordingExtractor.py
+++ b/spikeinterface/SubRecordingExtractor.py
@@ -33,9 +33,6 @@ class SubRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return self._channel_ids
 
-    def getNumChannels(self):
-        return len(self._channel_ids)
-
     def getNumFrames(self):
         return self._end_frame-self._start_frame
 

--- a/spikeinterface/SubRecordingExtractor.py
+++ b/spikeinterface/SubRecordingExtractor.py
@@ -30,6 +30,9 @@ class SubRecordingExtractor(RecordingExtractor):
         ef=self._start_frame+end_frame
         return self._parent_recording.getTraces(start_frame=sf,end_frame=ef,channel_ids=ch_ids)
 
+    def getChannelIds(self):
+        return self._channel_ids
+
     def getNumChannels(self):
         return len(self._channel_ids)
 

--- a/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -13,6 +13,9 @@ class BiocamRecordingExtractor(RecordingExtractor):
         for m in range(self._nRecCh):
             self.setChannelProperty(m,'location',self._positions[m])
 
+    def getChannelIds(self):
+        return list(range(self._nRecCh))
+
     def getNumChannels(self):
         return self._nRecCh
 

--- a/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -16,9 +16,6 @@ class BiocamRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._nRecCh))
 
-    def getNumChannels(self):
-        return self._nRecCh
-
     def getNumFrames(self):
         return self._nFrames
 

--- a/spikeinterface/extractors/mdaextractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors/mdaextractors.py
@@ -43,6 +43,9 @@ class MdaRecordingExtractor(RecordingExtractor):
         for m in range(self._num_channels):
             self.setChannelProperty(m,'location',self._geom[m,:])
 
+    def getChannelIds(self):
+        return list(range(self._num_channels))
+
     def getNumChannels(self):
         return self._num_channels
 

--- a/spikeinterface/extractors/mdaextractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors/mdaextractors.py
@@ -46,9 +46,6 @@ class MdaRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._num_channels))
 
-    def getNumChannels(self):
-        return self._num_channels
-
     def getNumFrames(self):
         return self._num_timepoints
 

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -98,7 +98,7 @@ class MEArecSortingExtractor(SortingExtractor):
         if 'unit_id' in rec_dict['spiketrains'][0].annotations:
             self._unit_ids = [st.annotations['unit_id'] for st in rec_dict['spiketrains']]
         else:
-            self._unit_ids = range(self._num_units)
+            self._unit_ids = list(range(self._num_units))
         self._spike_trains = rec_dict['spiketrains']
         self._fs  = info['recordings']['fs'] * pq.Hz #fs is in kHz
 
@@ -176,6 +176,7 @@ def load_recordings(recordings, verbose=False):
         print("Loading recordings...")
 
     rec_dict = {}
+    info = {}
 
     if os.path.isdir(recordings):
         recording_folder = recordings
@@ -205,7 +206,6 @@ def load_recordings(recordings, verbose=False):
     elif recordings.endswith('h5') or recordings.endswith('hdf5'):
         with h5py.File(recordings, 'r') as F:
             info = json.loads(str(F['info'][()]))
-            print(info)
             rec_dict['peaks'] = np.array(F.get('peaks'))
             rec_dict['positions'] = np.array(F.get('positions'))
             rec_dict['recordings'] = np.array(F.get('recordings'))
@@ -227,6 +227,8 @@ def load_recordings(recordings, verbose=False):
                     st.annotations = annotations
                     spiketrains.append(st)
                 rec_dict['spiketrains'] = spiketrains
+    else:
+        raise Exception("The provided file-folder is not a MEArec recording")
 
     if verbose:
         print("Done loading recordings...")

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -30,11 +30,6 @@ class MEArecRecordingExtractor(RecordingExtractor):
             self._initialize()
         return list(range(self._recordings.shape[0]))
 
-    def getNumChannels(self):
-        if self._recordings is None:
-            self._initialize()
-        return self._recordings.shape[0]
-
     def getNumFrames(self):
         if self._recordings is None:
             self._initialize()

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -25,6 +25,10 @@ class MEArecRecordingExtractor(RecordingExtractor):
         for chan, pos in enumerate(rec_dict['positions']):
             self.setChannelProperty(chan, 'location', pos)
 
+    def getChannelIds(self):
+        if self._recordings is None:
+            self._initialize()
+        return list(range(self._recordings.shape[0]))
 
     def getNumChannels(self):
         if self._recordings is None:

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -13,6 +13,9 @@ class NumpyRecordingExtractor(RecordingExtractor):
             for m in range(self._timeseries.shape[0]):
                 self.setChannelProperty(m,'location',self._geom[m,:])
 
+    def getChannelIds(self):
+        return list(range(self._timeseries.shape[0]))
+
     def getNumChannels(self):
         return self._timeseries.shape[0]
 

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -16,9 +16,6 @@ class NumpyRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._timeseries.shape[0]))
 
-    def getNumChannels(self):
-        return self._timeseries.shape[0]
-
     def getNumFrames(self):
         return self._timeseries.shape[1]
 

--- a/spikeinterface/extractors/nwbextractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors/nwbextractors.py
@@ -11,6 +11,9 @@ class CopyRecordingExtractor(si.RecordingExtractor):
         self._other=other
         self.copyChannelProperties(other)
 
+    def getChannelIds(self):
+        return list(range(self._other.getNumChannels()))
+
     def getNumChannels(self):
         return self._other.getNumChannels()
 

--- a/spikeinterface/extractors/nwbextractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors/nwbextractors.py
@@ -14,9 +14,6 @@ class CopyRecordingExtractor(si.RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._other.getNumChannels()))
 
-    def getNumChannels(self):
-        return self._other.getNumChannels()
-
     def getNumFrames(self):
         return self._other.getNumFrames()
 

--- a/spikeinterface/extractors/openephysextractors/openephysextractors.py
+++ b/spikeinterface/extractors/openephysextractors/openephysextractors.py
@@ -13,6 +13,9 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
         self._recording = pyopenephys.File(recording_file,
                                            probefile).experiments[experiment_id].recordings[recording_id]
 
+    def getChannelIds(self):
+        return list(range(self._recording.analog_signals[0].signal.shape[0]))
+
     def getNumChannels(self):
         return self._recording.analog_signals[0].signal.shape[0]
 

--- a/spikeinterface/extractors/openephysextractors/openephysextractors.py
+++ b/spikeinterface/extractors/openephysextractors/openephysextractors.py
@@ -16,9 +16,6 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
     def getChannelIds(self):
         return list(range(self._recording.analog_signals[0].signal.shape[0]))
 
-    def getNumChannels(self):
-        return self._recording.analog_signals[0].signal.shape[0]
-
     def getNumFrames(self):
         return self._recording.analog_signals[0].signal.shape[1]
 

--- a/spikeinterface/tools.py
+++ b/spikeinterface/tools.py
@@ -31,7 +31,7 @@ def read_python(path):
     return metadata
 
 
-def loadProbeFile(recording, probe_file, channel_map=None):
+def loadProbeFile(recording, probe_file, channel_map=None, channel_groups=None):
     '''Loads channel information into recording extractor. If a .prb file is given,
     then 'location' and 'group' information for each channel is stored. If a .csv
     file is given, then it will only store 'location'
@@ -68,25 +68,34 @@ def loadProbeFile(recording, probe_file, channel_map=None):
                 subrecording = SubRecordingExtractor(recording, channel_ids=ordered_channels)
             for cgroup_id in groups:
                 cgroup = probe_dict['channel_groups'][cgroup_id]
+                if 'channels' not in cgroup.keys() and len(groups) > 1:
+                    raise Exception("If more than one 'channel_group' is in the probe file, the 'channels' field"
+                                    "for each channel group is required")
+                elif 'channels' not in cgroup.keys():
+                    channels_in_group = subrecording.getNumChannels()
+                else:
+                    channels_in_group = len(cgroup['channels'])
                 for key_prop, prop_val in cgroup.items():
-                    if key_prop is not 'channels':
-                        if key_prop == 'geometry' or key_prop == 'location':
-                            if isinstance(prop_val, dict) and len(prop_val.keys()) == subrecording.getNumChannels():
-                                for (i_ch, prop) in prop_val.items():
-                                    subrecording.setChannelProperty(i_ch, 'location', prop)
-                            elif isinstance(prop_val, (list, np.ndarray)) and len(prop_val) == subrecording.getNumChannels():
-                                for (i_ch, prop) in zip(subrecording.getChannelIds(), prop_val):
-                                    subrecording.setChannelProperty(i_ch, 'location', prop)
-                        else:
-                            if isinstance(prop_val, dict) and len(prop_val.keys()) == subrecording.getNumChannels():
-                                for (i_ch, prop) in prop_val.items():
-                                    subrecording.setChannelProperty(i_ch, key_prop, prop)
-                            elif isinstance(prop_val, (list, np.ndarray)) and len(prop_val) == subrecording.getNumChannels():
-                                for (i_ch, prop) in zip(subrecording.getChannelIds(), prop_val):
-                                    subrecording.setChannelProperty(i_ch, key_prop, prop)
+                    if key_prop == 'channels':
+                        for i_ch, prop in enumerate(prop_val):
+                            subrecording.setChannelProperty(prop, 'group', int(cgroup_id))
+                    elif key_prop == 'geometry' or key_prop == 'location':
+                        if isinstance(prop_val, dict) and len(prop_val.keys()) == channels_in_group:
+                            for (i_ch, prop) in prop_val.items():
+                                subrecording.setChannelProperty(i_ch, 'location', prop)
+                        elif isinstance(prop_val, (list, np.ndarray)) and len(prop_val) == channels_in_group:
+                            for (i_ch, prop) in zip(subrecording.getChannelIds(), prop_val):
+                                subrecording.setChannelProperty(i_ch, 'location', prop)
+                    else:
+                        if isinstance(prop_val, dict) and len(prop_val.keys()) == channels_in_group:
+                            for (i_ch, prop) in prop_val.items():
+                                subrecording.setChannelProperty(i_ch, key_prop, prop)
+                        elif isinstance(prop_val, (list, np.ndarray)) and len(prop_val) == channels_in_group:
+                            for (i_ch, prop) in zip(subrecording.getChannelIds(), prop_val):
+                                subrecording.setChannelProperty(i_ch, key_prop, prop)
         else:
             raise AttributeError("'.prb' file should contain the 'channel_groups' field")
-        
+
     elif probe_file.endswith('.csv'):
         if channel_map is not None:
             assert np.all([chan in recording.getChannelIds() for chan in channel_map]), \
@@ -96,10 +105,18 @@ def loadProbeFile(recording, probe_file, channel_map=None):
             subrecording = recording
         with open(probe_file) as csvfile:
             posreader = csv.reader(csvfile)
-            row_count = sum(1 for row in posreader)
-            assert len(subrecording.getChannelIds()) == row_count
-            for i_ch, pos in zip(subrecording.getChannelIds(), posreader):
+            row_count = 0
+            loaded_pos = []
+            for pos in (posreader):
+                row_count += 1
+                loaded_pos.append(pos)
+            assert len(subrecording.getChannelIds()) == row_count, "The .csv file must contain as many " \
+                                                                   "rows as the number of channels in the recordings"
+            for i_ch, pos in zip(subrecording.getChannelIds(), loaded_pos):
                 subrecording.setChannelProperty(i_ch, 'location', list(np.array(pos).astype(float)))
+            if channel_groups is not None and len(channel_groups) == len(subrecording.getChannelIds()):
+                for i_ch, chg in zip(subrecording.getChannelIds(), channel_groups):
+                    subrecording.setChannelProperty(i_ch, 'group', chg)
     else:
         raise NotImplementedError("Only .csv and .prb probe files can be loaded.")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,15 +19,16 @@ class TestTools(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_load_save_probes(self):
-        si.loadProbeFile(self.RX, 'tests/probe_test.prb')
-        assert 'location' in self.RX.getChannelPropertyNames()
-        assert 'group' in self.RX.getChannelPropertyNames()
-        positions = [self.RX.getChannelProperty(chan, 'location') for chan in range(self.RX.getNumChannels())]
+        SX = si.loadProbeFile(self.RX, 'tests/probe_test.prb')
+        print(SX.getChannelPropertyNames())
+        assert 'location' in SX.getChannelPropertyNames()
+        assert 'group' in SX.getChannelPropertyNames()
+        positions = [SX.getChannelProperty(chan, 'location') for chan in range(self.RX.getNumChannels())]
         # save in csv
-        si.saveProbeFile(self.RX, self.test_dir+'geom.csv')
+        si.saveProbeFile(SX, self.test_dir+'geom.csv')
         # load csv locations
-        si.loadProbeFile(self.RX, self.test_dir+'geom.csv')
-        position_loaded = [self.RX.getChannelProperty(chan, 'location') for chan in range(self.RX.getNumChannels())]
+        SX_load = si.loadProbeFile(SX, self.test_dir+'geom.csv')
+        position_loaded = [SX_load.getChannelProperty(chan, 'location') for chan in range(SX_load.getNumChannels())]
         self.assertTrue(np.allclose(positions[10], position_loaded[10]))
 
     def test_write_dat_file(self):


### PR DESCRIPTION
- added `getChannelIds()`: if `self._channel_ids` is None, it returns `list(range(num_channels))`, otherwise it returns the list of channel_ids. Channels are handled as units in the SortingExtractors. The only way to change the channel ids is creating a `SubRecordingExtractor` with the `channel_ids` argument.

- updated `loadProbeFile()`:
    - returns a subrecording extractor
    - if 'channels' is in the probe file, it is considered the channel map
    - other properties can be loaded either by passing a dictionary channel_id: property, or a list with the length of the number of channels in the channel group
    - when loading locations from csv file, one can pass the `channel_map` and  `channel_group` arguments to load map and group information

- fixed some minor thing in Recording and Sorting extractor: `isinstance(id, (int, np.integer))` handles all possible numpy integers