### PR TITLE
Changed getTraces signature to match with the rest of SpikeInterface

### DIFF
--- a/spikeinterface/MultiRecordingExtractor.py
+++ b/spikeinterface/MultiRecordingExtractor.py
@@ -59,7 +59,7 @@ class MultiRecordingExtractor(RecordingExtractor):
         ind=inds[-1]
         return self._RXs[ind], ind, time-self._start_times[ind]
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:
@@ -67,17 +67,17 @@ class MultiRecordingExtractor(RecordingExtractor):
         RX1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
         RX2, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
         if i_sec1==i_sec2:
-            return RX1.getTraces(start_frame=i_start_frame,end_frame=i_end_frame,channel_ids=channel_ids)
+            return RX1.getTraces(channel_ids=channel_ids, start_frame=i_start_frame,end_frame=i_end_frame)
         list=[]
         list.append(
-            self._RXs[i_sec1].getTraces(start_frame=i_start_frame,end_frame=self._RXs[i_sec1].getNumFrames(),channel_ids=channel_ids)
+            self._RXs[i_sec1].getTraces(channel_ids=channel_ids, start_frame=i_start_frame,end_frame=self._RXs[i_sec1].getNumFrames())
         )
         for i_sec in range(i_sec1+1,i_sec2):
             list.append(
                 self._RXs[i_sec].getTraces(channel_ids=channel_ids)
             )
         list.append(
-            self._RXs[i_sec2].getTraces(start_frame=0,end_frame=i_end_frame,channel_ids=channel_ids)
+            self._RXs[i_sec2].getTraces(channel_ids=channel_ids, start_frame=0,end_frame=i_end_frame)
         )
         return np.concatenate(list,axis=1)
 

--- a/spikeinterface/RecordingExtractor.py
+++ b/spikeinterface/RecordingExtractor.py
@@ -14,7 +14,7 @@ class RecordingExtractor(ABC):
         self._channel_properties = {}
 
     @abstractmethod
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         '''This function extracts and returns a trace from the recorded data from the
         given channels ids and the given start and end frame. It will return
         traces from within three ranges:
@@ -183,9 +183,9 @@ class RecordingExtractor(ABC):
                 if snippet_range[1] >= num_frames:
                     snippet_buffer[1] -= snippet_range[1] - num_frames
                     snippet_range[1] -= snippet_range[1] - num_frames
-                snippet_chunk[:,snippet_buffer[0]:snippet_buffer[1]] = self.getTraces(start_frame=snippet_range[0],
-                                                                                      end_frame=snippet_range[1],
-                                                                                      channel_ids=channel_ids)
+                snippet_chunk[:,snippet_buffer[0]:snippet_buffer[1]] = self.getTraces(channel_ids=channel_ids,
+                                                                                      start_frame=snippet_range[0],
+                                                                                      end_frame=snippet_range[1])
             snippets.append(snippet_chunk)
 
         return snippets

--- a/spikeinterface/SubRecordingExtractor.py
+++ b/spikeinterface/SubRecordingExtractor.py
@@ -24,7 +24,7 @@ class SubRecordingExtractor(RecordingExtractor):
             self._original_channel_id_lookup[self._renamed_channel_ids[i]]=self._channel_ids[i]
         self.copyChannelProperties(parent_recording,channel_ids=self._renamed_channel_ids)
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:
@@ -34,7 +34,7 @@ class SubRecordingExtractor(RecordingExtractor):
         sf=self._start_frame+start_frame
         ef=self._start_frame+end_frame
         original_ch_ids = self.getOriginalChannelIds(channel_ids)
-        return self._parent_recording.getTraces(start_frame=sf,end_frame=ef,channel_ids=original_ch_ids)
+        return self._parent_recording.getTraces(channel_ids=original_ch_ids, start_frame=sf,end_frame=ef)
 
     def getChannelIds(self):
         return self._renamed_channel_ids

--- a/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeinterface/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -22,7 +22,7 @@ class BiocamRecordingExtractor(RecordingExtractor):
     def getSamplingFrequency(self):
         return self._samplingRate
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/spikeinterface/extractors/mdaextractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors/mdaextractors.py
@@ -52,7 +52,7 @@ class MdaRecordingExtractor(RecordingExtractor):
     def getSamplingFrequency(self):
         return self._samplerate
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         mdaio,kbucket=_load_required_modules()
 
         if start_frame is None:

--- a/spikeinterface/extractors/mearecextractors/mearecextractors.py
+++ b/spikeinterface/extractors/mearecextractors/mearecextractors.py
@@ -40,7 +40,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
             self._initialize()
         return self._fs
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if self._recordings is None:
             self._initialize()
         if start_frame is None:
@@ -233,4 +233,3 @@ def load_recordings(recordings, verbose=False):
         print("Done loading recordings...")
 
     return rec_dict, info
-

--- a/spikeinterface/extractors/numpyextractors/numpyextractors.py
+++ b/spikeinterface/extractors/numpyextractors/numpyextractors.py
@@ -22,7 +22,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
     def getSamplingFrequency(self):
         return self._samplerate
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if start_frame is None:
             start_frame=0
         if end_frame is None:

--- a/spikeinterface/extractors/nwbextractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors/nwbextractors.py
@@ -20,8 +20,8 @@ class CopyRecordingExtractor(si.RecordingExtractor):
     def getSamplingFrequency(self):
         return self._other.getSamplingFrequency()
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
-        return self._other.getTraces(start_frame=start_frame,end_frame=end_frame,channel_ids=channel_ids)
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
+        return self._other.getTraces(channel_ids=channel_ids, start_frame=start_frame,end_frame=end_frame)
 
 class NwbRecordingExtractor(CopyRecordingExtractor):
     def __init__(self, path, acquisition_name=None):

--- a/spikeinterface/extractors/openephysextractors/openephysextractors.py
+++ b/spikeinterface/extractors/openephysextractors/openephysextractors.py
@@ -22,7 +22,7 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
     def getSamplingFrequency(self):
         return float(self._recording.sample_rate.rescale('Hz').magnitude)
 
-    def getTraces(self, start_frame=None, end_frame=None, channel_ids=None):
+    def getTraces(self, channel_ids=None, start_frame=None, end_frame=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -175,8 +175,8 @@ class TestExtractors(unittest.TestCase):
         ))
         sf=0; ef=0; ch=[0,M-1]
         self.assertTrue(np.allclose(
-            RX1.getTraces(start_frame=sf,end_frame=ef,channel_ids=ch),
-            RX2.getTraces(start_frame=sf,end_frame=ef,channel_ids=ch)
+            RX1.getTraces(channel_ids=ch, start_frame=sf,end_frame=ef),
+            RX2.getTraces(channel_ids=ch, start_frame=sf,end_frame=ef)
         ))
         for f in range(0,RX1.getNumFrames(),10):
             self.assertTrue(np.isclose(RX1.frameToTime(f),RX2.frameToTime(f)))

--- a/tests/test_numpy_extractors.py
+++ b/tests/test_numpy_extractors.py
@@ -39,7 +39,7 @@ class TestNumpyExtractors(unittest.TestCase):
         self.assertEqual(self.RX.getSamplingFrequency(),self._samplerate)
         # getTraces
         self.assertTrue(np.allclose(self.RX.getTraces(),self._X))
-        self.assertTrue(np.allclose(self.RX.getTraces(start_frame=0,end_frame=12,channel_ids=[0,3]),self._X[[0,3],0:12]))
+        self.assertTrue(np.allclose(self.RX.getTraces(channel_ids=[0,3], start_frame=0,end_frame=12),self._X[[0,3],0:12]))
         # getChannelProperty - location
         self.assertTrue(np.allclose(np.array(self.RX.getChannelProperty(1,'location')),self._geom[1,:]))
         # timeToFrame / frameToTime


### PR DESCRIPTION
All other functions in SpikeInterface have channel_ids (or unit_id) as the first argument in the signature except the getTraces function. I changed all getTraces functions in the tests, extractors, and parent classes including the multi and sub extractors.

Original:
```
def getTraces(self, start_frame=None, end_frame=None, channel_ids=None)
```

Proposed change
```
def getTraces(self, channel_ids=None, start_frame=None, end_frame=None)
```

Other examples
```
def getUnitSpikeTrain(self, unit_id, start_frame=None, end_frame=None):

def setChannelProperty(self, channel_id, property_name, value):
```

